### PR TITLE
Fix poetry Python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.5"
+python = "~2.7 || >=3.5"
 mkdocs = { version = "*", optional = true }
 mkdocs-material = { version = "*", optional = true }
 


### PR DESCRIPTION
Your poetry requirements only allows 2.7 or 3.5.
This caused a problem when I tried to install dependencies using git with poetry.
Please merge so I can point myself to this repository's master branch.