### PR TITLE
Add conda-forge version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![docs](https://readthedocs.org/projects/dependencies/badge/?version=latest)](https://dependencies.readthedocs.io/en/latest/?badge=latest)
 [![gitter](https://badges.gitter.im/dry-python/dependencies.svg)](https://gitter.im/dry-python/dependencies)
 [![pypi](https://img.shields.io/pypi/v/dependencies.svg)](https://pypi.python.org/pypi/dependencies/)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/dependencies.svg)](https://anaconda.org/conda-forge/dependencies)
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 ---

--- a/docs/contrib/pytest.md
+++ b/docs/contrib/pytest.md
@@ -1,6 +1,6 @@
-# Py.Test contrib
+# pytest contrib
 
-[Py.test](https://docs.pytest.org/) is a state of art testing framework
+[pytest](https://docs.pytest.org/) is a state of art testing framework
 for Python.
 
 If you business objects have to do with a lot of third-party services,

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 [![docs](https://readthedocs.org/projects/dependencies/badge/?version=latest)](http://dependencies.readthedocs.io/en/latest/?badge=latest)
 [![gitter](https://badges.gitter.im/dry-python/dependencies.svg)](https://gitter.im/dry-python/dependencies)
 [![pypi](https://img.shields.io/pypi/v/dependencies.svg)](https://pypi.python.org/pypi/dependencies/)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/dependencies.svg)](https://anaconda.org/conda-forge/dependencies)
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 ---


### PR DESCRIPTION
I'm maintainer of the conda version of this package on conda-forge:

https://github.com/conda-forge/dependencies-feedstock

So I thought it would be nice to show the version of the conda-package on the README alongside PyPI's.